### PR TITLE
Loading on main page

### DIFF
--- a/src/components/Search.vue
+++ b/src/components/Search.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <section>
     <h3>Search for a class</h3>
     <form action="javascript:void(0);" name="main">
       <input type="text" v-model="Subject" placeholder="CSCI" required>
@@ -7,30 +7,58 @@
         <option value="Winter">Winter</option>
         <option value="Spring">Spring</option>
         <option value="Summer">Summer</option>
-        <option value="Fall" selected >Fall</option>
+        <option value="Fall" selected>Fall</option>
       </select>
       <button @click="search()">Search</button>
     </form>
-  </div>
+    <span v-if="this.resData === undefined">
+      <h3>There are no classes that match that search</h3>
+    </span>
+    <Donut v-else-if="this.requestMade"/>
+  </section>
 </template>
 
 <script>
+import Donut from '@/components/Donut.vue';
+import finder from '@/finder';
+
 export default {
   name: 'Search',
+  components: {
+    Donut,
+  },
   props: {},
   data() {
     return {
       Subject: '',
       Term: '',
+      resData: {},
+      requestMade: false,
     };
   },
   methods: {
-    search() {
+    async search() {
       if (this.Term && this.Subject) {
-        this.$router.push({
-          name: 'results',
-          params: { term: this.Term, subject: this.Subject },
-        });
+        this.resData = '';
+        this.requestMade = true;
+        const terms = {
+          Winter: 1,
+          Spring: 2,
+          Summer: 3,
+          Fall: 4,
+        };
+        const response = await finder(
+          this.Subject,
+          terms[this.Term],
+        );
+        this.resData = response.labeledChunks;
+        this.requestMade = false;
+        if (this.resData !== undefined) {
+          this.$router.push({
+            name: 'results',
+            params: { term: this.Term, subject: this.Subject, data: response.labeledChunks },
+          });
+        }
       }
     },
   },
@@ -42,9 +70,9 @@ export default {
 </script>
 
 <style scoped>
-div {
+section {
   width: 400px;
-  height: 120px;
+  height: 250px;
   margin: auto;
   box-shadow: var(--light-shadow);
 }

--- a/src/components/Search.vue
+++ b/src/components/Search.vue
@@ -11,9 +11,11 @@
       </select>
       <button @click="search()">Search</button>
     </form>
+    <!-- if the response contained no classes show error-->
     <span v-if="this.resData === undefined">
       <h3>There are no classes that match that search</h3>
     </span>
+    <!-- or if the request has just been made show loading animation -->
     <Donut v-else-if="this.requestMade"/>
   </section>
 </template>
@@ -38,6 +40,7 @@ export default {
   },
   methods: {
     async search() {
+      // check to make sure form has correct elements
       if (this.Term && this.Subject) {
         this.resData = '';
         this.requestMade = true;
@@ -47,12 +50,15 @@ export default {
           Summer: 3,
           Fall: 4,
         };
+        // call the parser with the form data
         const response = await finder(
           this.Subject,
           terms[this.Term],
         );
+        // store data to stop loading animation/show error if empty
         this.resData = response.labeledChunks;
         this.requestMade = false;
+        // if there were results, load results page
         if (this.resData !== undefined) {
           this.$router.push({
             name: 'results',

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -7,12 +7,11 @@
 <script>
 import Search from '@/components/Search.vue';
 
+
 export default {
   name: 'Home',
   components: {
     Search,
-  },
-  props: {
   },
 };
 </script>

--- a/src/views/Results.vue
+++ b/src/views/Results.vue
@@ -1,49 +1,18 @@
 <template>
-  <main v-if="this.resBody">
-    <!-- <div v-html="resBody"></div> -->
-    <div v-if="this.resData === undefined">
-      <h3>No results found</h3>
-    </div>
-    <div v-else>
-      <h1>{{this.$route.params.subject}} in {{this.termName}} term</h1>
-      <Class v-for="item in resData" :key="item.CRN" :data="item"></Class>
-    </div>
+  <main>
+    <h1>{{this.$route.params.subject}} in {{this.$route.params.term}} term</h1>
+    <Class v-for="item in this.$route.params.data" :key="item.CRN" :data="item"></Class>
   </main>
-  <Donut v-else/>
 </template>
 
 <script>
-import finder from '@/finder';
+
 import Class from '@/components/Class.vue';
-import Donut from '@/components/Donut.vue';
 
 export default {
   name: 'results',
   components: {
     Class,
-    Donut,
-  },
-  data() {
-    return {
-      resBody: '',
-      resData: {},
-      termName: '',
-    };
-  },
-  async mounted() {
-    const terms = {
-      Winter: 1,
-      Spring: 2,
-      Summer: 3,
-      Fall: 4,
-    };
-    this.termName = this.$route.params.term;
-    const response = await finder(
-      this.$route.params.subject,
-      terms[this.termName],
-    );
-    this.resBody = response.body;
-    this.resData = response.labeledChunks;
   },
 };
 </script>

--- a/src/views/Results.vue
+++ b/src/views/Results.vue
@@ -6,7 +6,6 @@
 </template>
 
 <script>
-
 import Class from '@/components/Class.vue';
 
 export default {


### PR DESCRIPTION
Moves loading of results to main page next to the search. This allows for rendering of empty results on the main page, preventing user navigation. Closes #1 